### PR TITLE
Add `servicestack-client` to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -506,6 +506,7 @@
   "select2": "github:select2/select2",
   "selectize": "github:selectize/selectize.js",
   "semantic-ui": "github:Semantic-Org/Semantic-UI",
+  "servicestack-client": "npm:servicestack-client",
   "scoped-polyfill": "github:PM5544/scoped-polyfill",
   "showdown": "github:showdownjs/showdown",
   "sifter": "github:brianreavis/sifter.js",


### PR DESCRIPTION
This is to add [servicestack-client](https://www.npmjs.com/package/servicestack-client) so it's available from `jspm install`.